### PR TITLE
DB: exec() commits + returns RETURNING; add insert()/upsert() helpers

### DIFF
--- a/code/dihlibs/db.py
+++ b/code/dihlibs/db.py
@@ -123,16 +123,80 @@ class DB:
         self.engine.dispose()
         return results
 
-    def exec(self, query, params=None):
+    def exec(self, query, params=None, format: ResultFormat = ResultFormat.LIST):
+        """Run a write statement (INSERT/UPDATE/DELETE/DDL) and COMMIT it.
+
+        Returns the affected rowcount, or -- when the statement carries a
+        RETURNING clause -- the returned rows, formatted exactly like
+        ``query()`` (list of dicts by default).
+
+        Runs inside ``engine.begin()`` so the transaction commits on success
+        and rolls back on exception. This is the only safe path for writes:
+        ``query()`` deliberately rolls back on connection close (so reads
+        don't sit idle-in-transaction holding ACCESS SHARE locks), which
+        silently discards any write sent through it -- including an
+        ``INSERT ... RETURNING``, where the sequence still advances (nextval
+        survives rollback) but the row never persists.
+        """
         query = self._bind(query, params)
-        with self.Session() as session:
-            try:
-                rs = session.execute(text(query), params)
-                session.commit()
-                return rs.rowcount
-            except Exception:
-                session.rollback()
-                raise
+        with self.engine.begin() as conn:
+            result = conn.execute(text(query), params or {})
+            # returns_rows is True for SELECT and for INSERT/UPDATE/DELETE with
+            # a RETURNING clause; False for a plain write or DDL.
+            if result.returns_rows:
+                return format(result.keys(), result.fetchall())
+            return result.rowcount
+
+    def insert(self, table, values: dict, returning=None):
+        """Insert one row from a dict and commit; optionally RETURNING.
+
+            db.insert("eidsr_log", {"signal_id": sid}, returning="signal_id")
+            # -> [{"signal_id": sid}]
+
+        Returns the rowcount when ``returning`` is omitted, else the rows
+        ``query()``-formatted. ``table``/``returning`` are interpolated as SQL,
+        so keep them literal (not user input); the row *values* are bound as
+        parameters.
+        """
+        cols = ", ".join(values)
+        binds = ", ".join(f":{k}" for k in values)
+        sql = f"INSERT INTO {table} ({cols}) VALUES ({binds})"
+        if returning:
+            sql += f" RETURNING {returning}"
+        return self.exec(sql, values)
+
+    def upsert(self, table, values: dict, conflict, update=None, returning=None):
+        """INSERT ... ON CONFLICT DO UPDATE one row from a dict, and commit.
+
+        ``conflict`` is the column (or list of columns) of the unique/PK
+        constraint to match on. ``update`` is the list of columns to overwrite
+        from the would-be-inserted row (via ``EXCLUDED``); it defaults to every
+        non-conflict column. Pass ``update=[]`` for ``DO NOTHING``.
+
+            db.upsert("eidsr_log",
+                      {"signal_id": sid, "last_status": st},
+                      conflict="signal_id",
+                      update=["last_status"])
+
+        Identifiers (``table``/``conflict``/``update``/``returning``) are
+        interpolated as SQL -- keep them literal; values are bound as params.
+        """
+        conflict = [conflict] if isinstance(conflict, str) else list(conflict)
+        if update is None:
+            update = [c for c in values if c not in conflict]
+        cols = ", ".join(values)
+        binds = ", ".join(f":{k}" for k in values)
+        sql = (
+            f"INSERT INTO {table} ({cols}) VALUES ({binds}) "
+            f"ON CONFLICT ({', '.join(conflict)}) DO "
+        )
+        if update:
+            sql += "UPDATE SET " + ", ".join(f"{c} = EXCLUDED.{c}" for c in update)
+        else:
+            sql += "NOTHING"
+        if returning:
+            sql += f" RETURNING {returning}"
+        return self.exec(sql, values)
 
     def _bind(self, sql, params=None):
         if params is None:

--- a/code/setup.py
+++ b/code/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="dihlibs",
-    version="0.0.98",
+    version="0.0.99",
     author="Nitu",
     author_email="nkataraia@d-tree.org",
     description="A helper package for data integrations",

--- a/code/tests/dihlibs/test_db_writes.py
+++ b/code/tests/dihlibs/test_db_writes.py
@@ -1,0 +1,90 @@
+"""Write-path tests for dihlibs.db.DB.
+
+Covers the contract that exec() COMMITS and surfaces RETURNING rows, and that
+the insert()/upsert() helpers build correct SQL and round-trip. Regression
+guard for the dihlibs 0.0.98 footgun where a write sent through query() was
+silently rolled back on connection close (the row vanished while the sequence
+advanced -> downstream 'row N not found').
+
+Uses a throwaway file-based SQLite database so the suite needs no external
+service. SQLite (3.35+) supports both RETURNING and ON CONFLICT ... DO UPDATE,
+which is all these helpers rely on; a file (not :memory:) is used so the
+separate connections opened by exec()/query() see each other's committed data.
+"""
+import os
+import tempfile
+
+import pytest
+
+from dihlibs.db import DB
+
+
+@pytest.fixture
+def db():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    database = DB(connection_url=f"sqlite:///{path}")
+    database.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, hits INTEGER)")
+    yield database
+    os.remove(path)
+
+
+def test_exec_commits_plain_insert(db):
+    # rowcount back, and the row is visible from query() -- a SEPARATE
+    # connection -- which only holds if exec() committed rather than rolled back.
+    assert db.exec(
+        "INSERT INTO t (id, name) VALUES (:id, :name)", {"id": 1, "name": "a"}
+    ) == 1
+    assert db.query("SELECT name FROM t WHERE id = :id", {"id": 1}) == [{"name": "a"}]
+
+
+def test_exec_returns_returning_rows(db):
+    rows = db.exec("INSERT INTO t (name) VALUES (:name) RETURNING id", {"name": "x"})
+    assert rows == [{"id": 1}]
+
+
+def test_exec_supports_bracket_placeholders(db):
+    # _bind still rewrites the [name] placeholder style for exec().
+    assert db.exec("INSERT INTO t (id, name) VALUES ([id], [name])",
+                   {"id": 7, "name": "b"}) == 1
+    assert db.query("SELECT name FROM t WHERE id = [id]", {"id": 7}) == [{"name": "b"}]
+
+
+def test_insert_helper_returns_id(db):
+    assert db.insert("t", {"name": "y"}, returning="id") == [{"id": 1}]
+
+
+def test_insert_helper_without_returning_gives_rowcount(db):
+    assert db.insert("t", {"id": 5, "name": "z"}) == 1
+    assert db.query("SELECT name FROM t WHERE id = :id", {"id": 5}) == [{"name": "z"}]
+
+
+def test_upsert_inserts_then_updates_on_conflict(db):
+    db.upsert("t", {"id": 1, "name": "a", "hits": 1}, conflict="id")
+    db.upsert("t", {"id": 1, "name": "b", "hits": 2}, conflict="id",
+              update=["name", "hits"])
+    assert db.query("SELECT name, hits FROM t WHERE id = :id", {"id": 1}) == [
+        {"name": "b", "hits": 2}
+    ]
+
+
+def test_upsert_default_update_covers_non_conflict_columns(db):
+    db.upsert("t", {"id": 1, "name": "a", "hits": 1}, conflict="id")
+    db.upsert("t", {"id": 1, "name": "c", "hits": 9}, conflict="id")
+    assert db.query("SELECT name, hits FROM t WHERE id = :id", {"id": 1}) == [
+        {"name": "c", "hits": 9}
+    ]
+
+
+def test_upsert_do_nothing_leaves_existing_row(db):
+    db.insert("t", {"id": 1, "name": "a", "hits": 1})
+    db.upsert("t", {"id": 1, "name": "b", "hits": 2}, conflict="id", update=[])
+    assert db.query("SELECT name, hits FROM t WHERE id = :id", {"id": 1}) == [
+        {"name": "a", "hits": 1}
+    ]
+
+
+def test_upsert_returning(db):
+    row = db.upsert("t", {"id": 1, "name": "a", "hits": 1}, conflict="id",
+                    returning="id")
+    assert row == [{"id": 1}]


### PR DESCRIPTION
## Why

Surfaced from a live prod incident in `jna-integrations`: after the dihlibs **0.0.98** bump, every inbound request returned 200 but the worker failed with `request_log row N not found`. Root cause is the gap between our two write paths:

- `exec()` commits, but returns only `rowcount` — it discards `RETURNING`.
- `query()` returns rows, but since 0.0.98 **rolls back on connection close** (the deliberate fix to stop reads holding `ACCESS SHARE` locks).

So `INSERT ... RETURNING id` had nowhere correct to go: sent through `query()`, the sequence advanced (`nextval` survives rollback) but the row never persisted. There was no method that both commits **and** returns rows.

## What

- **`exec()`** now runs inside `engine.begin()` (commit on success, rollback on exception) and returns the `RETURNING` rows — `query()`-formatted (list-of-dicts) — when the statement produces them, otherwise the rowcount. This removes the only reason to ever write through `query()`.
- **`insert(table, values, returning=None)`** and **`upsert(table, values, conflict, update=None, returning=None)`** dict helpers for the two dominant write shapes (`INSERT ... RETURNING`, `ON CONFLICT DO UPDATE`). Values are bound as params; identifiers are interpolated, so keep them literal.

## Compatibility

Backward compatible — plain (non-RETURNING) writes still return `rowcount`, so every existing `exec()` caller is unaffected. The only behavior change is `exec()` of a `RETURNING` statement, which previously returned a useless rowcount.

## Tests

`tests/dihlibs/test_db_writes.py` — 9 tests over a throwaway file-based SQLite DB (no external service): exec commit-visibility, RETURNING surfacing, `[name]` placeholder binding, and insert/upsert (default + explicit update, DO NOTHING, RETURNING). Full suite: 52 passed.

Bumps version to **0.0.99**.

> Base is `fixed-minor-issue` (the deployed 0.0.98 trunk), not `main` — `main` is a stale seed commit ~62 behind.